### PR TITLE
Fix for when using `afero.Walk` with a root path "/".

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -2,7 +2,9 @@ package bindatafs
 
 import (
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/afero"
 )
@@ -55,7 +57,9 @@ func (t *tree) dir(name string, create bool) *dir {
 }
 
 func (t *tree) grow(fs *Fs) error {
-	t.root = &dir{}
+	t.root = &dir{
+		info: &fileInfo{"", 0, os.ModeDir, time.Unix(0, 0), true},
+	}
 	names := fs.Names()
 	for _, name := range names {
 		dirName, fileName := split(name)


### PR DESCRIPTION
Was getting a panic on line 53 of afero's `path.go` because info was nil for the root directory.

```go
	if !info.IsDir() {
		return nil
	}
```